### PR TITLE
feat(plugins): add LlamaIndex tool guard plugin (Issue #22)

### DIFF
--- a/chimera_core/plugins/__init__.py
+++ b/chimera_core/plugins/__init__.py
@@ -1,1 +1,27 @@
-from .langchain import ChimeraRunnableGate, GuardedTool, wrap_tool__all__ = ["ChimeraRunnableGate", "GuardedTool", "wrap_tool"]
+from __future__ import annotations
+
+__all__ = []
+
+try:
+    from .langchain import ChimeraRunnableGate, GuardedTool, wrap_tool
+
+    wrap_langchain_tool = wrap_tool
+    __all__ += ["ChimeraRunnableGate", "GuardedTool", "wrap_tool", "wrap_langchain_tool"]
+except ImportError:
+    pass
+
+try:
+    from .llamaindex import ChimeraLlamaIndexGate, GuardedLlamaIndexTool
+    from .llamaindex import gate as llamaindex_gate
+    from .llamaindex import guard_tools as guard_llamaindex_tools
+    from .llamaindex import wrap_tool as wrap_llamaindex_tool
+
+    __all__ += [
+        "ChimeraLlamaIndexGate",
+        "GuardedLlamaIndexTool",
+        "llamaindex_gate",
+        "guard_llamaindex_tools",
+        "wrap_llamaindex_tool",
+    ]
+except ImportError:
+    pass

--- a/chimera_core/plugins/llamaindex.py
+++ b/chimera_core/plugins/llamaindex.py
@@ -1,0 +1,215 @@
+"""
+CSL-Core - LlamaIndex Integration Plugin
+
+Optional LlamaIndex guard plugin using the `ChimeraPlugin` architecture.
+Provides policy-aware wrappers for agent/tool interactions without forcing
+`llama_index` as a hard dependency at import time.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+
+from ..runtime import ChimeraGuard
+from .base import ChimeraPlugin, ContextMapper
+
+if TYPE_CHECKING:
+    try:
+        from llama_index.core.tools.types import BaseTool as LlamaIndexBaseTool
+    except ImportError:
+        from llama_index.core.tools import BaseTool as LlamaIndexBaseTool
+else:
+    LlamaIndexBaseTool = Any
+
+
+def _require_llamaindex() -> None:
+    """Raises a clear, friendly error when LlamaIndex is unavailable."""
+    try:
+        import llama_index.core  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "LlamaIndex plugin requires `llama-index-core`. "
+            "Install with: pip install llama-index-core"
+        ) from exc
+
+
+class ChimeraLlamaIndexGate(ChimeraPlugin):
+    """
+    Pass-through guard component for LlamaIndex pipelines.
+    Normalizes input, verifies policy, then returns original input unchanged.
+    """
+
+    def __init__(
+        self,
+        guard_or_constitution: Any,
+        *,
+        context_mapper: Optional[ContextMapper] = None,
+        inject: Optional[Dict[str, Any]] = None,
+        enable_dashboard: bool = False,
+    ):
+        _require_llamaindex()
+        if isinstance(guard_or_constitution, ChimeraGuard):
+            constitution = guard_or_constitution.constitution
+        else:
+            constitution = guard_or_constitution
+
+        super().__init__(
+            constitution=constitution,
+            enable_dashboard=enable_dashboard,
+            context_mapper=context_mapper,
+            title="LlamaIndex::Gate",
+        )
+        self.inject = inject or {}
+
+    def process(self, input_data: Any) -> Any:
+        return self.__call__(input_data)
+
+    def __call__(self, input_data: Any) -> Any:
+        self.run_guard(input_data, extra_context=self.inject)
+        return input_data
+
+
+def gate(
+    guard: Any,
+    *,
+    context_mapper: Optional[ContextMapper] = None,
+    inject: Optional[Dict[str, Any]] = None,
+    enable_dashboard: bool = False,
+) -> ChimeraLlamaIndexGate:
+    """Helper to create a ChimeraLlamaIndexGate."""
+    return ChimeraLlamaIndexGate(
+        guard,
+        context_mapper=context_mapper,
+        inject=inject,
+        enable_dashboard=enable_dashboard,
+    )
+
+
+class _ToolPlugin(ChimeraPlugin):
+    """Internal helper to bridge LlamaIndex tool calls into ChimeraPlugin logic."""
+
+    def process(self, input_data: Any) -> Any:
+        return input_data
+
+
+class GuardedLlamaIndexTool:
+    """
+    Wrapper that enforces policy before executing a LlamaIndex tool call.
+    Uses composition to avoid framework inheritance/version coupling.
+    """
+
+    def __init__(
+        self,
+        tool: LlamaIndexBaseTool,
+        plugin: _ToolPlugin,
+        *,
+        inject: Optional[Dict[str, Any]] = None,
+        tool_field: Optional[str] = None,
+    ):
+        self.original_tool = tool
+        self._plugin = plugin
+        self._inject = inject or {}
+        self._tool_field = tool_field
+
+    @property
+    def metadata(self) -> Any:
+        return getattr(self.original_tool, "metadata", None)
+
+    @property
+    def name(self) -> str:
+        metadata = self.metadata
+        if metadata is not None and getattr(metadata, "name", None):
+            return str(metadata.name)
+        return str(getattr(self.original_tool, "name", "unknown"))
+
+    @property
+    def description(self) -> str:
+        metadata = self.metadata
+        if metadata is not None and getattr(metadata, "description", None):
+            return str(metadata.description)
+        return str(getattr(self.original_tool, "description", ""))
+
+    def _build_extra_context(self) -> Dict[str, Any]:
+        extra = self._inject.copy()
+        if self._tool_field:
+            extra[self._tool_field] = self.name
+        return extra
+
+    def _normalize_tool_input(self, *args: Any, **kwargs: Any) -> Any:
+        if kwargs:
+            return kwargs
+        if args:
+            return args[0]
+        return {}
+
+    def call(self, *args: Any, **kwargs: Any) -> Any:
+        tool_input = self._normalize_tool_input(*args, **kwargs)
+        self._plugin.run_guard(tool_input, extra_context=self._build_extra_context())
+
+        if hasattr(self.original_tool, "call"):
+            return self.original_tool.call(*args, **kwargs)
+        if callable(self.original_tool):
+            return self.original_tool(*args, **kwargs)
+        raise TypeError("Wrapped tool does not implement `call` and is not callable.")
+
+    async def acall(self, *args: Any, **kwargs: Any) -> Any:
+        tool_input = self._normalize_tool_input(*args, **kwargs)
+        self._plugin.run_guard(tool_input, extra_context=self._build_extra_context())
+
+        if hasattr(self.original_tool, "acall"):
+            return await self.original_tool.acall(*args, **kwargs)
+        return self.call(*args, **kwargs)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.call(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.original_tool, name)
+
+
+def wrap_tool(
+    tool: LlamaIndexBaseTool,
+    guard: ChimeraGuard,
+    *,
+    context_mapper: Optional[ContextMapper] = None,
+    inject: Optional[Dict[str, Any]] = None,
+    tool_field: Optional[str] = None,
+    enable_dashboard: bool = False,
+) -> GuardedLlamaIndexTool:
+    """Wrap a LlamaIndex tool with ChimeraGuard protection."""
+    _require_llamaindex()
+    plugin = _ToolPlugin(
+        constitution=guard.constitution,
+        enable_dashboard=enable_dashboard,
+        context_mapper=context_mapper,
+        title=f"Tool::{getattr(getattr(tool, 'metadata', None), 'name', getattr(tool, 'name', 'unknown'))}",
+    )
+    return GuardedLlamaIndexTool(
+        tool,
+        plugin,
+        inject=inject,
+        tool_field=tool_field,
+    )
+
+
+def guard_tools(
+    tools: Iterable[LlamaIndexBaseTool],
+    guard: ChimeraGuard,
+    *,
+    context_mapper: Optional[ContextMapper] = None,
+    inject: Optional[Dict[str, Any]] = None,
+    tool_field: Optional[str] = None,
+    enable_dashboard: bool = False,
+) -> List[GuardedLlamaIndexTool]:
+    """Wrap multiple LlamaIndex tools at once."""
+    return [
+        wrap_tool(
+            t,
+            guard,
+            context_mapper=context_mapper,
+            inject=inject,
+            tool_field=tool_field,
+            enable_dashboard=enable_dashboard,
+        )
+        for t in tools
+    ]

--- a/examples/integrations/llamaindex_agent_demo.py
+++ b/examples/integrations/llamaindex_agent_demo.py
@@ -1,0 +1,216 @@
+"""
+ChimeraGuard x LlamaIndex integration demo.
+
+This demo shows how to:
+1. Compile and load a CSL policy.
+2. Wrap LlamaIndex tools with ChimeraGuard.
+3. Enforce policy before each tool call.
+4. Handle ALLOW/BLOCK outcomes deterministically.
+
+Run from repository root:
+    python examples/integrations/llamaindex_agent_demo.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+try:
+    from llama_index.core.tools import FunctionTool
+except ImportError:
+    print("Missing dependency: llama-index-core")
+    print('Install with: pip install -e ".[llamaindex]"')
+    raise SystemExit(1)
+
+
+from chimera_core.language.compiler import CSLCompiler
+from chimera_core.language.parser import parse_csl_file
+from chimera_core.plugins.llamaindex import guard_tools
+from chimera_core.runtime import ChimeraError, ChimeraGuard
+
+
+def load_guard(policy_path: Path) -> ChimeraGuard:
+    """Compile a CSL policy file and return a ready-to-use guard."""
+    if not policy_path.exists():
+        raise FileNotFoundError(f"Policy file not found: {policy_path}")
+    constitution = parse_csl_file(str(policy_path))
+    compiled = CSLCompiler().compile(constitution)
+    return ChimeraGuard(compiled)
+
+
+def build_tools() -> List[Any]:
+    """Create raw LlamaIndex tools used by the demo."""
+
+    def send_email(recipient_domain: str, pii_present: str) -> str:
+        return f"EMAIL_SENT:{recipient_domain}:{pii_present}"
+
+    def transfer_funds(amount: int, approval_token: str = "NO") -> str:
+        return f"TRANSFER_OK:{amount}:approval={approval_token}"
+
+    def query_db(db_table: str) -> str:
+        return f"QUERY_OK:{db_table}"
+
+    return [
+        FunctionTool.from_defaults(
+            fn=send_email,
+            name="SEND_EMAIL",
+            description="Send an email to a target domain.",
+        ),
+        FunctionTool.from_defaults(
+            fn=transfer_funds,
+            name="TRANSFER_FUNDS",
+            description="Transfer funds after policy checks.",
+        ),
+        FunctionTool.from_defaults(
+            fn=query_db,
+            name="QUERY_DB",
+            description="Query a logical table.",
+        ),
+    ]
+
+
+def context_mapper(tool_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Map tool kwargs into the policy schema.
+
+    This keeps policy variable names stable even if tool signatures differ.
+    """
+    return {
+        "amount": tool_kwargs.get("amount", 0),
+        "approval_token": tool_kwargs.get("approval_token", "NO"),
+        "recipient_domain": tool_kwargs.get("recipient_domain"),
+        "pii_present": tool_kwargs.get("pii_present"),
+        "db_table": tool_kwargs.get("db_table"),
+    }
+
+
+def build_guarded_tool_map(guarded_tools_iter: Iterable[Any]) -> Dict[str, Any]:
+    """Index guarded tools by name for explicit scenario selection."""
+    return {tool.name: tool for tool in guarded_tools_iter}
+
+
+def run_sync_case(
+    name: str,
+    tool: Any,
+    kwargs: Dict[str, Any],
+    expected: str,
+) -> Tuple[str, str, str, str]:
+    """
+    Execute one synchronous case.
+
+    Returns: (case_name, expected, actual, detail)
+    """
+    try:
+        result = tool.call(**kwargs)
+        return (name, expected, "ALLOW", str(result))
+    except ChimeraError as exc:
+        return (name, expected, "BLOCK", f"{exc.constraint_name}")
+    except Exception as exc:
+        return (name, expected, "ERROR", str(exc))
+
+
+async def run_async_case(
+    name: str,
+    tool: Any,
+    kwargs: Dict[str, Any],
+    expected: str,
+) -> Tuple[str, str, str, str]:
+    """Execute one asynchronous case through acall."""
+    try:
+        result = await tool.acall(**kwargs)
+        return (name, expected, "ALLOW", str(result))
+    except ChimeraError as exc:
+        return (name, expected, "BLOCK", f"{exc.constraint_name}")
+    except Exception as exc:
+        return (name, expected, "ERROR", str(exc))
+
+
+def print_summary(rows: List[Tuple[str, str, str, str]]) -> None:
+    """Simple deterministic text summary."""
+    print("\nLlamaIndex Guard Demo Results")
+    print("-" * 90)
+    print(f"{'Case':34} {'Expected':10} {'Actual':10} Detail")
+    print("-" * 90)
+    passed = 0
+    for case_name, expected, actual, detail in rows:
+        if expected == actual:
+            passed += 1
+        print(f"{case_name:34} {expected:10} {actual:10} {detail}")
+    print("-" * 90)
+    print(f"Passed: {passed}/{len(rows)}")
+
+
+async def main() -> None:
+    policy_path = PROJECT_ROOT / "examples" / "agent_tool_guard.csl"
+    guard = load_guard(policy_path)
+
+    raw_tools = build_tools()
+
+    user_tools = build_guarded_tool_map(
+        guard_tools(
+            raw_tools,
+            guard,
+            context_mapper=context_mapper,
+            inject={"user_role": "USER"},
+            tool_field="tool",
+        )
+    )
+    admin_tools = build_guarded_tool_map(
+        guard_tools(
+            raw_tools,
+            guard,
+            context_mapper=context_mapper,
+            inject={"user_role": "ADMIN"},
+            tool_field="tool",
+        )
+    )
+
+    results: List[Tuple[str, str, str, str]] = []
+
+    results.append(
+        run_sync_case(
+            "USER external PII email",
+            user_tools["SEND_EMAIL"],
+            {"recipient_domain": "EXTERNAL", "pii_present": "YES"},
+            "BLOCK",
+        )
+    )
+    results.append(
+        run_sync_case(
+            "ADMIN internal PII email",
+            admin_tools["SEND_EMAIL"],
+            {"recipient_domain": "INTERNAL", "pii_present": "YES"},
+            "ALLOW",
+        )
+    )
+    results.append(
+        run_sync_case(
+            "USER transfer attempt",
+            user_tools["TRANSFER_FUNDS"],
+            {"amount": 1000, "approval_token": "YES"},
+            "BLOCK",
+        )
+    )
+    results.append(
+        await run_async_case(
+            "ADMIN async DB query",
+            admin_tools["QUERY_DB"],
+            {"db_table": "CUSTOMERS"},
+            "ALLOW",
+        )
+    )
+
+    print_summary(results)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -66,6 +66,11 @@ POLICIES = {
         "path": "integrations/langchain_agent_demo.py",
         "description": "Interactive LangChain Agent with visual dashboard"
     },
+    "llamaindex_agent_demo": {
+        "type": "script",
+        "path": "integrations/llamaindex_agent_demo.py",
+        "description": "LlamaIndex FunctionTool demo with ChimeraGuard enforcement"
+    },
     "openclaw_guard": {
         "policy": "openclaw_guard.csl",
         "tests": "openclaw_guard_tests.json",
@@ -352,14 +357,22 @@ def run_integration_script(name: str) -> bool:
 def list_available_policies():
     """List all available policies"""
     console.print("\n[bold cyan]Available Policies:[/bold cyan]\n")
-    
+
     for name, info in POLICIES.items():
+        if info.get("type") == "script":
+            script_path = EXAMPLES_DIR / info["path"]
+            status = "[green]OK[/green]" if script_path.exists() else "[red]NO[/red]"
+            console.print(f"  {status} [cyan]{name}[/cyan]")
+            console.print(f"     {info['description']}")
+            console.print(f"     Script: {info['path']}")
+            console.print()
+            continue
+
         policy_path = EXAMPLES_DIR / info["policy"]
         test_path = JSON_DIR / info["tests"]
-        
-        status = "✅" if policy_path.exists() else "❌"
-        test_status = "✅" if test_path.exists() else "❌"
-        
+        status = "[green]OK[/green]" if policy_path.exists() else "[red]NO[/red]"
+        test_status = "[green]OK[/green]" if test_path.exists() else "[red]NO[/red]"
+
         console.print(f"  {status} [cyan]{name}[/cyan]")
         console.print(f"     {info['description']}")
         console.print(f"     Policy: {info['policy']} | Tests: {test_status} {info['tests']}")
@@ -466,3 +479,4 @@ Examples:
 
 if __name__ == "__main__":
     sys.exit(main())
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "CSL-Core: Deterministic Safety Layer for Probabilistic AI Systems
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
-keywords = ["ai-safety", "formal-verification", "langchain", "policy-engine", "z3"]
+keywords = ["ai-safety", "formal-verification", "langchain", "llamaindex", "policy-engine", "z3"]
 
 authors = [
     {name = "Aytug Akarlar", email = "akarlaraytu@gmail.com"},
@@ -42,6 +42,10 @@ langchain = [
     "langchain-core>=0.1.0",
     "pydantic>=2.0.0",
 ]
+llamaindex = [
+    "llama-index-core>=0.10.0",
+    "pydantic>=2.0.0",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov",
@@ -49,6 +53,7 @@ dev = [
     "black",
     "mypy",
     "langchain-core>=0.1.0",
+    "llama-index-core>=0.10.0",
     "pydantic>=2.0.0",
 ]
 

--- a/tests/integration/test_langchain.py
+++ b/tests/integration/test_langchain.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 from chimera_core.runtime import ChimeraGuard, ChimeraError
-from chimera_core.plugins.langchain import ChimeraRunnableGate, wrap_tool
 
 # --- 1. Bağımlılık Kontrolü ---
 def _has_langchain_core() -> bool:
@@ -24,6 +23,8 @@ def test_lcel_runnable_gate_pass_through(compiled_agent_tool_guard):
     """
     Test ChimeraRunnableGate using the shared compiled policy from conftest.py
     """
+    from chimera_core.plugins.langchain import ChimeraRunnableGate
+
     guard = ChimeraGuard(compiled_agent_tool_guard)
 
     gate = ChimeraRunnableGate(
@@ -50,6 +51,7 @@ def test_tool_wrapper_blocks_external_pii(compiled_agent_tool_guard):
     """
     Test Tool Wrapper enforcing DLP rules using the shared policy.
     """
+    from chimera_core.plugins.langchain import wrap_tool
     from langchain_core.tools import BaseTool
     from pydantic import BaseModel, Field
 
@@ -97,4 +99,5 @@ def test_tool_wrapper_blocks_external_pii(compiled_agent_tool_guard):
             "user_role": "ADMIN"
         })
     
-    assert "no_external_email_with_pii" in str(excinfo.value) or "Violation" in str(excinfo.value)
+    msg = str(excinfo.value).lower()
+    assert ("no_external_email_with_pii" in msg) or ("violation" in msg)

--- a/tests/integration/test_llamaindex.py
+++ b/tests/integration/test_llamaindex.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from chimera_core.runtime import ChimeraError, ChimeraGuard
+from chimera_core.plugins.llamaindex import ChimeraLlamaIndexGate, wrap_tool
+
+
+def _has_llama_index() -> bool:
+    try:
+        import llama_index.core  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _has_llama_index(),
+    reason="llama-index-core not installed; integration test skipped.",
+)
+
+
+def _extract_tool_value(result):
+    if isinstance(result, str):
+        return result
+    if hasattr(result, "raw_output"):
+        return str(result.raw_output)
+    if hasattr(result, "content"):
+        return str(result.content)
+    return str(result)
+
+
+def test_llamaindex_gate_pass_through(compiled_agent_tool_guard):
+    guard = ChimeraGuard(compiled_agent_tool_guard)
+    gate = ChimeraLlamaIndexGate(
+        guard,
+        context_mapper=lambda x: x if isinstance(x, dict) else {"content": str(x)},
+        inject={
+            "tool": "NOOP",
+            "user_role": "ADMIN",
+            "recipient_domain": "INTERNAL",
+            "target_table": "CUSTOMERS",
+            "pii_present": "NO",
+            "approval_token": "NO",
+        },
+    )
+
+    x = {"hello": "world"}
+    y = gate(x)
+    assert y is x
+
+
+def test_llamaindex_tool_wrapper_blocks_external_pii(compiled_agent_tool_guard):
+    from llama_index.core.tools import FunctionTool
+
+    guard = ChimeraGuard(compiled_agent_tool_guard)
+
+    def send_email(recipient_domain: str, pii_present: str, user_role: str = "ADMIN") -> str:
+        return "sent"
+
+    tool = FunctionTool.from_defaults(
+        fn=send_email,
+        name="SEND_EMAIL",
+        description="Test tool: send email",
+    )
+
+    def mapper(tool_kwargs: dict) -> dict:
+        return {
+            "tool": "SEND_EMAIL",
+            "user_role": tool_kwargs.get("user_role", "ADMIN"),
+            "pii_present": tool_kwargs.get("pii_present"),
+            "recipient_domain": tool_kwargs.get("recipient_domain"),
+        }
+
+    guarded = wrap_tool(tool, guard, context_mapper=mapper)
+
+    out = guarded.call(
+        recipient_domain="INTERNAL",
+        pii_present="YES",
+        user_role="ADMIN",
+    )
+    assert _extract_tool_value(out) == "sent"
+
+    with pytest.raises(ChimeraError) as excinfo:
+        guarded.call(
+            recipient_domain="EXTERNAL",
+            pii_present="YES",
+            user_role="ADMIN",
+        )
+    err = excinfo.value
+    assert err.constraint_name == "no_external_email_with_pii"
+    assert err.context.get("tool") == "SEND_EMAIL"


### PR DESCRIPTION
## Summary
This PR introduces an **optional LlamaIndex integration** that guards tool execution using Chimera policies, mirroring the existing LangChain plugin behavior. The guard intercepts both sync (`call`) and async (`acall`) tool execution, runs the Chimera enforcement lifecycle, and blocks/raises on policy violations.

## What’s included
- **New LlamaIndex plugin:** `chimera_core/plugins/llamaindex.py`
  - Wraps LlamaIndex tools to enforce policies before execution.
  - Supports **sync + async** tool calls.
  - Keeps LlamaIndex as an **optional dependency** (safe imports).
- **Public exports:** `chimera_core/plugins/__init__.py`
  - Adds LlamaIndex exports behind optional imports.
  - Keeps backward compatibility for LangChain exports and adds an explicit alias `wrap_langchain_tool`.
- **Integration tests**
  - Adds `tests/integration/test_llamaindex.py` mirroring the LangChain integration tests.
  - Improves robustness in `tests/integration/test_langchain.py` (lazy imports + more stable assertions).
- **Packaging**
  - Adds the `llamaindex` optional extra in `pyproject.toml` and updates keywords.

## How to test
### Base test suite
```bash
pytest -q
```

### With LlamaIndex installed (runs LlamaIndex integration tests)
```bash
pip install -e ".[llamaindex]"
pytest -q tests/integration/test_llamaindex.py
```

## Notes
- LlamaIndex remains **optional**: importing `chimera_core` does not require installing LlamaIndex.
- The implementation is intentionally aligned with the LangChain plugin’s enforcement flow for consistency.

## Checklist
- [x] `pytest -q` passes locally
- [x] LlamaIndex integration tests pass with `pip install -e ".[llamaindex]"`
- [x] Optional dependency behavior validated (tests skip when LlamaIndex is not installed)
